### PR TITLE
Fix POST attack check, global leaks, nil guards, and add rule/log cac…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project overview
+
+A WAF (Web Application Firewall) for Nginx/OpenResty written in Lua (~420 lines). It runs in the Nginx `access_by_lua_file` phase and sequentially checks each request against rule files (regex patterns), logging and blocking matches.
+
+## Architecture
+
+```
+nginx.conf (http block)
+  ├── init_by_lua_file → waf/init.lua     — defines all check functions (loaded once at startup)
+  └── access_by_lua_file → waf/access.lua — calls waf_main() on every request
+
+Request flow through waf_main() in access.lua:
+  white_ip_check → white_url_check → black_ip_check → user_agent_attack_check
+  → cc_attack_check → cookie_attack_check → url_attack_check
+  → url_args_attack_check → post_attack_check
+```
+
+Each check reads its corresponding rule file from `rule-config/`, then iterates rules with `ngx.re.find(str, rule, "jo")`. First match short-circuits — whitelist checks allow the request through; all others block it.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `waf/config.lua` | All configuration: on/off toggles per check, CC rate limit, log/output paths, custom 403 HTML. Uses global `config_*` variables. |
+| `waf/access.lua` | Entry point. Requires `init`, calls `waf_main()`. |
+| `waf/init.lua` | Defines the 9 check functions (`white_ip_check`, `black_ip_check`, `white_url_check`, `cc_attack_check`, `cookie_attack_check`, `url_attack_check`, `url_args_attack_check`, `user_agent_attack_check`, `post_attack_check`). Requires `config` and `lib`. |
+| `waf/lib.lua` | Shared utilities: `get_client_ip()` (checks X_real_ip → X_Forwarded_For → remote_addr), `get_rule(filename)` (reads a rule file into a table), `log_record()` (writes JSON log lines), `waf_output()` (renders 403 HTML or redirect). |
+| `waf/rule-config/*.rule` | Plain-text rule files, one regex per line. `ngx.re.find` with `"jo"` flags (JIT-compiled, cached). |
+
+## Rule files
+
+- `whiteip.rule` / `blackip.rule` — IP whitelist/blacklist (both empty by default)
+- `whiteurl.rule` — URL path whitelist (default: only `/123/`)
+- `url.rule` — Sensitive paths/extensions to block
+- `args.rule` — Query string attack patterns (SQLi, XSS)
+- `post.rule` — POST body attack patterns
+- `cookie.rule` — Cookie attack patterns
+- `useragent.rule` — Malicious crawler/scanner UA patterns
+
+## Nginx integration (required directives)
+
+```nginx
+lua_shared_dict limit 50m;
+lua_package_path "/usr/local/openresty/nginx/conf/waf/?.lua";
+init_by_lua_file  "/usr/local/openresty/nginx/conf/waf/init.lua";
+access_by_lua_file "/usr/local/openresty/nginx/conf/waf/access.lua";
+```
+
+The `resty` library must be symlinked: `ln -s /usr/local/openresty/lualib/resty/ /usr/local/openresty/nginx/conf/waf/resty`
+
+## Configuration
+
+All settings are in `waf/config.lua` as global Lua variables prefixed `config_`. Key ones:
+
+- `config_waf_enable` — master kill switch (`"on"`/`"off"`)
+- `config_cc_rate = "10/60"` — 10 requests per 60 seconds per IP+URI
+- `config_waf_output = "html"` — block response type (`"html"` or `"redirect"`)
+- `config_rule_dir` / `config_log_dir` — paths for rule files and JSON logs
+
+## No build/lint/test infrastructure
+
+This is pure Lua deployed directly into Nginx. There is no build system, package manager, linter config, or test framework. To test changes, deploy to an OpenResty instance and verify with `nginx -t` then `nginx -s reload`.

--- a/waf/init.lua
+++ b/waf/init.lua
@@ -62,8 +62,11 @@ function cc_attack_check()
         local ATTACK_URI=ngx.var.uri
         local CC_TOKEN = get_client_ip()..ATTACK_URI
         local limit = ngx.shared.limit
-        CCcount=tonumber(string.match(config_cc_rate,'(.*)/'))
-        CCseconds=tonumber(string.match(config_cc_rate,'/(.*)'))
+        if limit == nil then
+            return false
+        end
+        local CCcount=tonumber(string.match(config_cc_rate,'(.*)/'))
+        local CCseconds=tonumber(string.match(config_cc_rate,'/(.*)'))
         local req,_ = limit:get(CC_TOKEN)
         if req then
             if req > CCcount then
@@ -96,7 +99,7 @@ function cookie_attack_check()
                     end
                 end
              end
-	 end
+         end
     end
     return false
 end
@@ -123,13 +126,17 @@ end
 function url_args_attack_check()
     if config_url_args_check == "on" then
         local REQ_ARGS,ERR = ngx.req.get_uri_args()
-            -- limit max args to stop uri parameter overflow , return 403 if args larger than default(100)
-            if err == "truncated" then
+            -- limit max post args to stop uri parameter overflow , return 403 if args larger than default(100)
+            if ERR == "truncated" then
                 ngx.exit(403)
             end
+        if REQ_ARGS == nil then
+            return false
+        end
         local ARGS_RULES = get_rule('args.rule')
         for _,rule in pairs(ARGS_RULES) do
             for key, val in pairs(REQ_ARGS) do
+                local ARGS_DATA
                 if type(val) == 'table' then
                     ARGS_DATA = table.concat(val, " ")
                 else
@@ -176,27 +183,28 @@ function post_attack_check()
             if err == "truncated" then
                 ngx.exit(403)
             end
+        if POST_ARGS == nil then
+            return false
+        end
         local POST_RULES = get_rule('post.rule')
 
-    	for key, val in pairs(POST_ARGS) do
-            if type(val) == "table" then
-	            ARGS_DATA = table.concat(key, ", ")
-            else
-                ARGS_DATA = key
-            end 
-	    end
-
         for _,rule in pairs(POST_RULES) do
-            if ARGS_DATA and type(ARGS_DATA) ~= "boolean" and rule ~="" and rulematch(unescape(ARGS_DATA),rule,"jo") then
-                log_record('Deny_POST_Args',ngx.var.request_uri,"-",rule)
-                if config_waf_enable == "on" then
-                    waf_output()
-                    return true
+            for key, val in pairs(POST_ARGS) do
+                local POST_DATA
+                if type(val) == 'table' then
+                    POST_DATA = table.concat(val, " ")
+                else
+                    POST_DATA = val
+                end
+                if POST_DATA and type(POST_DATA) ~= "boolean" and rule ~="" and rulematch(unescape(POST_DATA),rule,"jo") then
+                    log_record('Deny_POST_Args',ngx.var.request_uri,"-",rule)
+                    if config_waf_enable == "on" then
+                        waf_output()
+                        return true
+                    end
                 end
             end
         end
-        return true
     end
     return false
 end
-

--- a/waf/lib.lua
+++ b/waf/lib.lua
@@ -3,7 +3,7 @@ require 'config'
 
 --Get the client IP
 function get_client_ip()
-    CLIENT_IP = ngx.req.get_headers()["X_real_ip"]
+    local CLIENT_IP = ngx.req.get_headers()["X_real_ip"]
     if CLIENT_IP == nil then
         CLIENT_IP = ngx.req.get_headers()["X_Forwarded_For"]
     end
@@ -18,33 +18,43 @@ end
 
 --Get the client user agent
 function get_user_agent()
-    USER_AGENT = ngx.var.http_user_agent
+    local USER_AGENT = ngx.var.http_user_agent
     if USER_AGENT == nil then
        USER_AGENT = "unknown"
     end
     return USER_AGENT
 end
 
+--Rule file cache (loaded once per worker on first access)
+local rule_cache = {}
+
 --Get WAF rule
 function get_rule(rulefilename)
+    if rule_cache[rulefilename] then
+        return rule_cache[rulefilename]
+    end
     local io = require 'io'
     local RULE_PATH = config_rule_dir
     local RULE_FILE = io.open(RULE_PATH..'/'..rulefilename,"r")
     if RULE_FILE == nil then
-        return
+        return nil
     end
-    RULE_TABLE = {}
+    local RULE_TABLE = {}
     for line in RULE_FILE:lines() do
         table.insert(RULE_TABLE,line)
     end
     RULE_FILE:close()
-    return(RULE_TABLE)
+    rule_cache[rulefilename] = RULE_TABLE
+    return RULE_TABLE
 end
 
 --WAF log record for json,(use logstash codec => json)
+--Keeps log file handle open across requests; only reopens on date change
+local log_file_handle = nil
+local log_file_date = nil
+
 function log_record(method,url,data,ruletag)
     local cjson = require("cjson")
-    local io = require 'io'
     local LOG_PATH = config_log_dir
     local CLIENT_IP = get_client_ip()
     local USER_AGENT = get_user_agent()
@@ -61,14 +71,21 @@ function log_record(method,url,data,ruletag)
                  rule_tag = ruletag,
               }
     local LOG_LINE = cjson.encode(log_json_obj)
-    local LOG_NAME = LOG_PATH..'/'..ngx.today().."_waf.log"
-    local file = io.open(LOG_NAME,"a")
-    if file == nil then
+    local today = ngx.today()
+    if log_file_date ~= today then
+        if log_file_handle then
+            log_file_handle:close()
+        end
+        local io = require 'io'
+        local LOG_NAME = LOG_PATH..'/'..today.."_waf.log"
+        log_file_handle = io.open(LOG_NAME,"a")
+        log_file_date = today
+    end
+    if log_file_handle == nil then
         return
     end
-    file:write(LOG_LINE.."\n")
-    file:flush()
-    file:close()
+    log_file_handle:write(LOG_LINE.."\n")
+    log_file_handle:flush()
 end
 
 --WAF return
@@ -82,4 +99,3 @@ function waf_output()
         ngx.exit(ngx.status)
     end
 end
-


### PR DESCRIPTION
…hing

- post_attack_check: fix loop to check each POST key/value against rules (was only checking the last key), fix table.concat on wrong variable, return false when no attack found instead of always true
- Add nil guard for ngx.shared.limit in cc_attack_check
- Add nil guards for get_uri_args/get_post_args return values
- Add local to all previously global variables (CCcount, CCseconds, ARGS_DATA, CLIENT_IP, USER_AGENT, RULE_TABLE) to prevent cross-request contamination
- Cache rule files in memory after first load (was reading from disk every request)
- Buffer log file handle across requests, reopening only on date change (was opening/closing per log line)
- Fix err → ERR typo in url_args_attack_check for consistency